### PR TITLE
Improve scaling & metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ Customize by commenting/uncommenting the desired method calls in `filter_analysi
 ## 5. Scaling Optimization
 
 After alignment, each filtered output can be scaled around a reference angle
-close to 90°. The script performs a grid search over reference angles (85–95°)
-and scale factors (0.9–1.1) to minimize **Extrema_MAE** on the aligned signal.
-The chosen `ref_angle` and `scale_k` values, along with the resulting
-`Extrema_MAE_scaled`, are recorded for each filter.
+close to 90°. Scaling is determined in two steps: first the reference angle is
+selected by minimizing overall MAE (searching 80–100° in 1° steps with a range
+of scale factors), then the scale factor is chosen to minimize
+**Extrema_MAE** at the fixed reference. The chosen `ref_angle` and
+`scale_k` values, along with the resulting `Extrema_MAE_scaled`, are recorded
+for each filter.
 
 ---
 
@@ -119,6 +121,8 @@ After alignment:
 - **MAVE_vl**: mean absolute error at true-valley indices.
 - **Extrema_MAE**: mean absolute error over all true-peak+valley indices.
 - **Extrema_MAE_scaled**: extrema MAE after the scaling optimization.
+- **RMSE_scaled**: RMSE after scaling optimization.
+- **MAE_scaled**: MAE after scaling optimization.
 
 ---
 


### PR DESCRIPTION
## Summary
- tune scaling optimization to search reference angles 80-100° and perform a two‑step optimization
- include scaled RMSE and MAE in the metrics table
- update legends to show scaled curves
- document new optimisation and metrics in README

## Testing
- `pip install -q -r requirements.txt`
- `python filter_analysis.py > /tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_684194cc4b488323b82ab54da5f4a703